### PR TITLE
Fix BlogPostForm update message

### DIFF
--- a/src/__tests__/BlogPostForm.test.jsx
+++ b/src/__tests__/BlogPostForm.test.jsx
@@ -189,4 +189,24 @@ describe("BlogPostForm", () => {
       expect(screen.getByTestId("datepicker")).toHaveValue("2025-01-01");
     });
   });
+
+  it("shows update success message when editing a post", async () => {
+    const onSubmit = jest.fn();
+    const existingPost = {
+      title: "Existing",
+      content: "Existing content",
+      author: "Author",
+      date: "2024-01-01",
+    };
+    render(<BlogPostForm post={existingPost} onSubmit={onSubmit} />);
+
+    fillForm();
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Post updated successfully/i)
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/BlogPostForm/BlogPostForm.jsx
+++ b/src/components/BlogPostForm/BlogPostForm.jsx
@@ -36,9 +36,12 @@ const BlogPostForm = ({ post = {}, onSubmit }) => {
       setIsSubmitting(true);
       await onSubmit({ title, content, author, date });
       setIsSubmitting(false);
-      setSuccessMessage("Post created successfully!");
+      const isEdit = post && Object.keys(post).length > 0;
+      setSuccessMessage(
+        isEdit ? "Post updated successfully!" : "Post created successfully!"
+      );
 
-      if (!post || Object.keys(post).length === 0) {
+      if (!isEdit) {
         setTitle("");
         setContent("");
         setAuthor("");


### PR DESCRIPTION
## Summary
- show a different success message when editing an existing post
- add a unit test to verify the update success message

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840f40bcf988327a94aa026a3acb767