### PR TITLE
Implement post deletion with confirmation dialog

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,8 @@ import {
 import BlogPostList from "./components/BlogPostList/BlogPostList";
 import BlogPostDetail from "./components/BlogPostDetail/BlogPostDetail";
 import BlogPostForm from "./components/BlogPostForm/BlogPostForm";
+import DeleteButton from "./components/DeleteButton/DeleteButton";
+import ConfirmationDialog from "./components/ConfirmationDialog/ConfirmationDialog";
 
 // Sample initial posts
 const initialPosts = [
@@ -111,36 +113,53 @@ const PostsPage = ({ posts }) => {
 };
 
 // Single post detail page
-const PostPage = ({ posts }) => {
+const PostPage = ({ posts, onDelete }) => {
   const { id } = useParams();
   const navigate = useNavigate();
+  const [isDialogOpen, setDialogOpen] = useState(false);
   const post = posts.find((p) => p.id === id);
 
   if (!post) return <p>Blog post not found.</p>;
 
+  const handleConfirmDelete = () => {
+    onDelete(id);
+    setDialogOpen(false);
+    navigate('/posts');
+  };
+
   return (
-    <div style={{ position: "relative", maxWidth: "800px", margin: "0 auto" }}>
+    <div style={{ position: 'relative', maxWidth: '800px', margin: '0 auto' }}>
       <button
         onClick={() => navigate(`/posts/${id}/edit`)}
         style={{
-          position: "absolute",
-          top: "10px",
-          right: "10px",
-          padding: "10px 15px",
-          fontSize: "14px",
-          marginRight: "40px",
-          marginTop: "20px",
-          backgroundColor: "#007BFF",
-          color: "#fff",
-          border: "none",
-          borderRadius: "4px",
-          cursor: "pointer",
+          position: 'absolute',
+          top: '10px',
+          right: '10px',
+          padding: '10px 15px',
+          fontSize: '14px',
+          marginRight: '40px',
+          marginTop: '20px',
+          backgroundColor: '#007BFF',
+          color: '#fff',
+          border: 'none',
+          borderRadius: '4px',
+          cursor: 'pointer',
         }}
       >
         Edit Post
       </button>
 
+      <div style={{ position: 'absolute', top: '10px', left: '10px' }}>
+        <DeleteButton onClick={() => setDialogOpen(true)} />
+      </div>
+
       <BlogPostDetail {...post} />
+
+      <ConfirmationDialog
+        isOpen={isDialogOpen}
+        onClose={() => setDialogOpen(false)}
+        onConfirm={handleConfirmDelete}
+      />
     </div>
   );
 };
@@ -196,6 +215,10 @@ const App = () => {
     setPosts(updatedPosts);
   };
 
+  const handleDeletePost = (id) => {
+    setPosts(posts.filter((p) => p.id !== id));
+  };
+
   return (
     <Router>
       <div>
@@ -203,7 +226,7 @@ const App = () => {
         <Routes>
           <Route path="/posts" element={<PostsPage posts={posts} />} />
           <Route path="/posts/new" element={<CreatePost onCreate={handleCreatePost} />} />
-          <Route path="/posts/:id" element={<PostPage posts={posts} />} />
+          <Route path="/posts/:id" element={<PostPage posts={posts} onDelete={handleDeletePost} />} />
           <Route path="/posts/:id/edit" element={<EditPost posts={posts} onUpdate={handleUpdatePost} />} />
           <Route path="*" element={<Navigate to="/posts" replace />} />
         </Routes>

--- a/src/__tests__/ConfirmationDialog.test.jsx
+++ b/src/__tests__/ConfirmationDialog.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ConfirmationDialog from '../components/ConfirmationDialog/ConfirmationDialog';
+
+describe('ConfirmationDialog', () => {
+  const setup = (props) =>
+    render(
+      <ConfirmationDialog isOpen={true} onClose={props.onClose} onConfirm={props.onConfirm} />
+    );
+
+  test('renders when open', () => {
+    setup({ onClose: jest.fn(), onConfirm: jest.fn() });
+    expect(screen.getByText(/Are you sure/i)).toBeInTheDocument();
+  });
+
+  test('calls onConfirm when delete clicked', () => {
+    const onConfirm = jest.fn();
+    setup({ onClose: jest.fn(), onConfirm });
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onClose when cancel clicked', () => {
+    const onClose = jest.fn();
+    setup({ onClose, onConfirm: jest.fn() });
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onClose when clicking overlay', () => {
+    const onClose = jest.fn();
+    render(
+      <ConfirmationDialog isOpen={true} onClose={onClose} onConfirm={jest.fn()} />
+    );
+    fireEvent.mouseDown(screen.getByRole('dialog').parentElement);
+    fireEvent.click(screen.getByRole('dialog').parentElement);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('calls onClose on Escape key', () => {
+    const onClose = jest.fn();
+    render(
+      <ConfirmationDialog isOpen={true} onClose={onClose} onConfirm={jest.fn()} />
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('returns null when not open', () => {
+    const { container } = render(
+      <ConfirmationDialog isOpen={false} onClose={jest.fn()} onConfirm={jest.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/__tests__/DeleteButton.test.jsx
+++ b/src/__tests__/DeleteButton.test.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DeleteButton from '../components/DeleteButton/DeleteButton';
+
+describe('DeleteButton', () => {
+  test('renders button and handles click', () => {
+    const onClick = jest.fn();
+    render(<DeleteButton onClick={onClick} />);
+    const btn = screen.getByRole('button', { name: /delete/i });
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ConfirmationDialog/ConfirmationDialog.jsx
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.jsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useRef } from 'react';
+import styles from './ConfirmationDialog.module.css';
+
+const ConfirmationDialog = ({ isOpen, onClose, onConfirm }) => {
+  const dialogRef = useRef(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      dialogRef.current?.focus();
+      const handleKey = (e) => {
+        if (e.key === 'Escape') {
+          onClose();
+        }
+      };
+      document.addEventListener('keydown', handleKey);
+      return () => document.removeEventListener('keydown', handleKey);
+    }
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div
+        className={styles.dialog}
+        role="dialog"
+        aria-labelledby="dialog-title"
+        aria-describedby="dialog-description"
+        ref={dialogRef}
+        tabIndex="-1"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="dialog-title" className={styles.title}>Confirm Deletion</h2>
+        <p id="dialog-description" className={styles.description}>
+          Are you sure you want to delete this post?
+        </p>
+        <div className={styles.buttons}>
+          <button onClick={onClose} className={styles.cancel}>Cancel</button>
+          <button onClick={onConfirm} className={styles.delete}>Delete</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmationDialog;

--- a/src/components/ConfirmationDialog/ConfirmationDialog.module.css
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.module.css
@@ -1,0 +1,79 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.dialog {
+  background-color: #FFFFFF;
+  max-width: 400px;
+  width: 90%;
+  padding: 30px;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  font-family: Arial, sans-serif;
+  outline: none;
+}
+
+.title {
+  font-size: 24px;
+  font-weight: bold;
+  color: #333333;
+  margin: 0 0 20px 0;
+}
+
+.description {
+  font-size: 16px;
+  color: #666666;
+  margin: 0 0 30px 0;
+}
+
+.buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 20px;
+}
+
+.cancel {
+  background-color: #CCCCCC;
+  color: #000000;
+  border: none;
+  border-radius: 4px;
+  padding: 10px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.delete {
+  background-color: #FF0000;
+  color: #FFFFFF;
+  border: none;
+  border-radius: 4px;
+  padding: 10px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.cancel:focus,
+.delete:focus {
+  outline: 2px solid #007BFF;
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .dialog {
+    width: 90%;
+  }
+
+  .buttons {
+    flex-direction: column;
+    gap: 10px;
+  }
+}

--- a/src/components/DeleteButton/DeleteButton.jsx
+++ b/src/components/DeleteButton/DeleteButton.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styles from './DeleteButton.module.css';
+
+const DeleteButton = ({ onClick, disabled }) => {
+  return (
+    <button
+      className={styles.deleteButton}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      Delete
+    </button>
+  );
+};
+
+export default DeleteButton;

--- a/src/components/DeleteButton/DeleteButton.module.css
+++ b/src/components/DeleteButton/DeleteButton.module.css
@@ -1,0 +1,29 @@
+.deleteButton {
+  background-color: #FF0000;
+  color: #FFFFFF;
+  border: none;
+  border-radius: 4px;
+  padding: 10px 20px;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  font-family: Arial, sans-serif;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.deleteButton:focus {
+  outline: 2px solid #007BFF;
+  outline-offset: 2px;
+}
+
+.deleteButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  .deleteButton {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add DeleteButton and ConfirmationDialog components
- support deleting posts from detail view
- test new DeleteButton and ConfirmationDialog components

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840f47342748327a9eb600535d9af79