### PR TITLE
Add responsive navigation and layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Add a search bar to the blogging platform, allowing users to search for posts by
 *Description:*
 Participate in code reviews and collaborate with peers to improve the quality of the blogging platform’s codebase, focusing on the newly added features.
 
+# Challenge 5: Implement Responsive Navigation and Layout
+*Description:*
+Create a reusable navigation bar and page layout so the app works well on both desktop and mobile devices. The navigation includes a logo, links, and a mobile menu toggle. The layout renders the navigation at the top, content in the middle, and a footer at the bottom.
+
 ## Steps to Run
 1. Visit the official Node.js website: https://nodejs.org
 2. Download the installer for your operating system (Windows, macOS, Linux) and follow the installation steps

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import BlogPostDetail from "./components/BlogPostDetail/BlogPostDetail";
 import BlogPostForm from "./components/BlogPostForm/BlogPostForm";
 import DeleteButton from "./components/DeleteButton/DeleteButton";
 import ConfirmationDialog from "./components/ConfirmationDialog/ConfirmationDialog";
+import Layout from "./components/Layout/Layout";
 
 // Sample initial posts
 const initialPosts = [
@@ -221,16 +222,16 @@ const App = () => {
 
   return (
     <Router>
-      <div>
-        <h1>Blog Posts</h1>
+      <Layout>
         <Routes>
+          <Route path="/" element={<Navigate to="/posts" replace />} />
           <Route path="/posts" element={<PostsPage posts={posts} />} />
           <Route path="/posts/new" element={<CreatePost onCreate={handleCreatePost} />} />
           <Route path="/posts/:id" element={<PostPage posts={posts} onDelete={handleDeletePost} />} />
           <Route path="/posts/:id/edit" element={<EditPost posts={posts} onUpdate={handleUpdatePost} />} />
           <Route path="*" element={<Navigate to="/posts" replace />} />
         </Routes>
-      </div>
+      </Layout>
     </Router>
   );
 };

--- a/src/__tests__/Layout.test.jsx
+++ b/src/__tests__/Layout.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import Layout from '../components/Layout/Layout';
+
+const Sample = () => <div>content</div>;
+
+describe('Layout', () => {
+  test('renders children with header and footer', () => {
+    render(
+      <BrowserRouter>
+        <Layout>
+          <Sample />
+        </Layout>
+      </BrowserRouter>
+    );
+
+    expect(screen.getByText('content')).toBeInTheDocument();
+    expect(screen.getByText('BlogApp')).toBeInTheDocument();
+    expect(screen.getByText(/all rights reserved/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/NavBar.test.jsx
+++ b/src/__tests__/NavBar.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NavBar from '../components/NavBar/NavBar';
+
+describe('NavBar', () => {
+  test('renders logo and links', () => {
+    render(
+      <BrowserRouter>
+        <NavBar />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByText('BlogApp')).toBeInTheDocument();
+    expect(screen.getByTestId('desktop-links')).toBeInTheDocument();
+  });
+
+  test('toggles mobile menu', () => {
+    render(
+      <BrowserRouter>
+        <NavBar />
+      </BrowserRouter>
+    );
+
+    const hamburger = screen.getByTestId('hamburger');
+    fireEvent.click(hamburger);
+    expect(screen.getByTestId('mobile-menu')).toBeInTheDocument();
+
+    fireEvent.click(hamburger);
+    expect(screen.queryByTestId('mobile-menu')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import NavBar from '../NavBar/NavBar';
+import styles from './Layout.module.css';
+
+const Layout = ({ children }) => {
+  return (
+    <div className={styles.layout}>
+      <header className={styles.header}>
+        <NavBar />
+      </header>
+      <main className={styles.main}>{children}</main>
+      <footer className={styles.footer}>
+        <p>&copy; 2023 BlogApp. All rights reserved.</p>
+      </footer>
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -1,0 +1,40 @@
+.layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  font-family: Arial, sans-serif;
+}
+
+.header {
+  flex-shrink: 0;
+}
+
+.main {
+  flex: 1;
+  padding: 80px 20px 20px; /* Account for fixed navbar */
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.footer {
+  flex-shrink: 0;
+  background-color: #003366;
+  color: #ffffff;
+  text-align: center;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+}
+
+@media (max-width: 768px) {
+  .main {
+    padding: 80px 10px 10px;
+  }
+  .footer {
+    font-size: 14px;
+  }
+}

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import styles from './NavBar.module.css';
+
+const NavBar = () => {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  const toggleMobileMenu = () => {
+    setIsMobileMenuOpen((prev) => !prev);
+  };
+
+  const closeMobileMenu = () => {
+    setIsMobileMenuOpen(false);
+  };
+
+  return (
+    <nav className={styles.navBar}>
+      <Link to="/" className={styles.logo} onClick={closeMobileMenu}>
+        BlogApp
+      </Link>
+      <div className={styles.links} data-testid="desktop-links">
+        <Link to="/" onClick={closeMobileMenu}>Home</Link>
+        <Link to="/posts" onClick={closeMobileMenu}>Blog</Link>
+        <Link to="/about" onClick={closeMobileMenu}>About</Link>
+      </div>
+      <button
+        className={styles.hamburger}
+        onClick={toggleMobileMenu}
+        aria-label="Toggle menu"
+        aria-expanded={isMobileMenuOpen}
+        data-testid="hamburger"
+      >
+        {isMobileMenuOpen ? '\u2715' : '\u2630'}
+      </button>
+      {isMobileMenuOpen && (
+        <div className={styles.mobileMenu} data-testid="mobile-menu">
+          <Link to="/" onClick={closeMobileMenu}>Home</Link>
+          <Link to="/posts" onClick={closeMobileMenu}>Blog</Link>
+          <Link to="/about" onClick={closeMobileMenu}>About</Link>
+        </div>
+      )}
+    </nav>
+  );
+};
+
+export default NavBar;

--- a/src/components/NavBar/NavBar.module.css
+++ b/src/components/NavBar/NavBar.module.css
@@ -1,0 +1,65 @@
+.navBar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 60px;
+  background-color: #003366;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+  z-index: 1000;
+}
+
+.logo {
+  font-size: 24px;
+  font-weight: bold;
+  color: #ffffff;
+  text-decoration: none;
+}
+
+.links a {
+  margin-left: 20px;
+  color: #ffffff;
+  text-decoration: none;
+  font-size: 18px;
+}
+
+.hamburger {
+  display: none;
+  background: none;
+  border: none;
+  color: #ffffff;
+  font-size: 32px;
+  cursor: pointer;
+}
+
+.mobileMenu {
+  position: absolute;
+  top: 60px;
+  left: 0;
+  right: 0;
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  padding: 10px 0;
+  transition: all 0.3s ease;
+}
+
+.mobileMenu a {
+  color: #003366;
+  padding: 10px 20px;
+  font-size: 18px;
+  text-decoration: none;
+}
+
+@media (max-width: 768px) {
+  .links {
+    display: none;
+  }
+  .hamburger {
+    display: block;
+  }
+}

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,1 +1,8 @@
 import '@testing-library/jest-dom';
+
+// JSDOM environment in Jest doesn't include TextEncoder/TextDecoder by default
+// which are required by React Router. Node provides them under 'util'.
+import { TextEncoder, TextDecoder } from 'util';
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;


### PR DESCRIPTION
## Summary
- introduce `NavBar` with responsive links and mobile menu
- create `Layout` component shared across routes
- wrap app routes with `Layout`
- add missing TextEncoder/Decoder polyfills for tests
- document Challenge 5 in README
- add tests for new components

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840f9e80fb88327b6b8ac90099f3c1e